### PR TITLE
Add settings for font

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -15,6 +15,8 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
     ui->scrollbackSpin->setValue(settings.value("term/scrollback", -1).toInt());
 
     connect(filter, SIGNAL(keypressCaptureComplete()), this, SLOT(keypressCaptureComplete()));
+
+	ui->fontSizeSpin->setValue(settings.value("appearance/fontSize", 10).toInt());
 }
 
 SettingsWindow::~SettingsWindow()
@@ -56,4 +58,9 @@ void SettingsWindow::keypressCaptureComplete() {
 void SettingsWindow::on_scrollbackSpin_valueChanged(int arg1)
 {
     settings.setValue("term/scrollback", arg1);
+}
+
+void SettingsWindow::on_fontSizeSpin_valueChanged(int arg1)
+{
+    settings.setValue("appearance/fontSize", arg1);
 }

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -16,6 +16,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
 
     connect(filter, SIGNAL(keypressCaptureComplete()), this, SLOT(keypressCaptureComplete()));
 
+	ui->fontComboBox->setCurrentFont(QFont(settings.value("appearance/font", "Monospace").toString()));
 	ui->fontSizeSpin->setValue(settings.value("appearance/fontSize", 10).toInt());
 }
 
@@ -58,6 +59,11 @@ void SettingsWindow::keypressCaptureComplete() {
 void SettingsWindow::on_scrollbackSpin_valueChanged(int arg1)
 {
     settings.setValue("term/scrollback", arg1);
+}
+
+void SettingsWindow::on_fontComboBox_currentFontChanged(const QFont &font)
+{
+	settings.setValue("appearance/font", font.family());
 }
 
 void SettingsWindow::on_fontSizeSpin_valueChanged(int arg1)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -45,6 +45,8 @@ private slots:
 
     void on_scrollbackSpin_valueChanged(int arg1);
 
+	void on_fontSizeSpin_valueChanged(int arg1);
+
 private:
     Ui::SettingsWindow *ui;
 

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -7,6 +7,7 @@
 #include <QKeySequenceEdit>
 #include <QX11Info>
 #include <QSpinBox>
+#include <QFont>
 #include "nativeeventfilter.h"
 #include <X11/Xlib.h>
 #include <X11/XF86keysym.h>
@@ -45,6 +46,7 @@ private slots:
 
     void on_scrollbackSpin_valueChanged(int arg1);
 
+	void on_fontComboBox_currentFontChanged(const QFont &font);
 	void on_fontSizeSpin_valueChanged(int arg1);
 
 private:

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -192,7 +192,7 @@
          </item>
         </layout>
        </widget>
-	   <widget class="QWidget" name="page_3"> <!--                 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee -->
+	   <widget class="QWidget" name="page_3">
         <layout class="QGridLayout" name="gridLayout_3">
          <item row="1" column="0">
           <widget class="QLabel" name="label_7">
@@ -255,6 +255,16 @@
            </property>
            <property name="text">
             <string>Appearance</string>
+           </property>
+          </widget>
+	     </item>
+		 <item row="2" column="0" colspan="3">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>This setting only applies to new terminals.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -36,7 +36,8 @@
          <string>General</string>
         </property>
         <property name="icon">
-         <iconset theme="configure"/>
+         <iconset theme="configure">
+          <normaloff>.</normaloff>.</iconset>
         </property>
        </item>
        <item>
@@ -44,7 +45,8 @@
          <string>Dropdown</string>
         </property>
         <property name="icon">
-         <iconset theme="go-down"/>
+         <iconset theme="go-down">
+          <normaloff>.</normaloff>.</iconset>
         </property>
        </item>
        <item>
@@ -52,7 +54,8 @@
          <string>Appearance</string>
         </property>
         <property name="icon">
-         <iconset theme="video-display"/>
+         <iconset theme="video-display">
+          <normaloff>.</normaloff>.</iconset>
         </property>
        </item>
       </widget>
@@ -60,7 +63,7 @@
      <item>
       <widget class="QStackedWidget" name="pages">
        <property name="currentIndex">
-        <number>0</number>
+        <number>2</number>
        </property>
        <widget class="QWidget" name="page">
         <layout class="QGridLayout" name="gridLayout">
@@ -192,16 +195,26 @@
          </item>
         </layout>
        </widget>
-	   <widget class="QWidget" name="page_3">
+       <widget class="QWidget" name="page_3">
         <layout class="QGridLayout" name="gridLayout_3">
-         <item row="1" column="0">
+         <item row="3" column="0" colspan="3">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>These settings only applies to new terminals.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
           <widget class="QLabel" name="label_7">
            <property name="text">
             <string>Font Size</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <spacer name="verticalSpacer_3">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -214,7 +227,26 @@
            </property>
           </spacer>
          </item>
-         <item row="1" column="1">
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="text">
+            <string>Font</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="3">
+          <widget class="QLabel" name="label_6">
+           <property name="font">
+            <font>
+             <pointsize>15</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Appearance</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
           <widget class="QSpinBox" name="fontSizeSpin">
            <property name="suffix">
             <string/>
@@ -233,38 +265,18 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+         <item row="1" column="1" colspan="2">
+          <widget class="QFontComboBox" name="fontComboBox">
+           <property name="currentText">
+            <string>Nimbus Mono PS</string>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
+           <property name="fontFilters">
+            <set>QFontComboBox::MonospacedFonts</set>
            </property>
-          </spacer>
-         </item>
-         <item row="0" column="0" colspan="3">
-          <widget class="QLabel" name="label_6">
-           <property name="font">
+           <property name="currentFont">
             <font>
-             <pointsize>15</pointsize>
+             <family>Nimbus Mono PS</family>
             </font>
-           </property>
-           <property name="text">
-            <string>Appearance</string>
-           </property>
-          </widget>
-	     </item>
-		 <item row="2" column="0" colspan="3">
-          <widget class="QLabel" name="label_8">
-           <property name="text">
-            <string>This setting only applies to new terminals.</string>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -47,6 +47,14 @@
          <iconset theme="go-down"/>
         </property>
        </item>
+       <item>
+        <property name="text">
+         <string>Appearance</string>
+        </property>
+        <property name="icon">
+         <iconset theme="video-display"/>
+        </property>
+       </item>
       </widget>
      </item>
      <item>
@@ -179,6 +187,74 @@
            </property>
            <property name="checkable">
             <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+	   <widget class="QWidget" name="page_3"> <!--                 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee -->
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Font Size</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <spacer name="verticalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="fontSizeSpin">
+           <property name="suffix">
+            <string/>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+           <property name="value">
+            <number>10</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="0" colspan="3">
+          <widget class="QLabel" name="label_6">
+           <property name="font">
+            <font>
+             <pointsize>15</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Appearance</string>
            </property>
           </widget>
          </item>

--- a/terminalwidget.cpp
+++ b/terminalwidget.cpp
@@ -12,10 +12,10 @@ terminalWidget::terminalWidget(QString workDir, QWidget *parent) : QTermWidget(0
         this->copyOk = copyAvailable;
     });
 
-    /*QFont font;
-    font.setFamily("Hack");
-    font.setPointSize(10);
-    this->setTerminalFont(font);*/
+    QFont font;
+    font.setFamily("Monospace");
+    font.setPointSize(settings.value("appearance/fontSize", 10).toInt());
+    this->setTerminalFont(font);
 
     QStringList environment;
     environment.append("TERM=xterm");

--- a/terminalwidget.cpp
+++ b/terminalwidget.cpp
@@ -13,7 +13,7 @@ terminalWidget::terminalWidget(QString workDir, QWidget *parent) : QTermWidget(0
     });
 
     QFont font;
-    font.setFamily("Monospace");
+    font.setFamily(settings.value("appearance/font", "Monospace").toString());
     font.setPointSize(settings.value("appearance/fontSize", 10).toInt());
     this->setTerminalFont(font);
 


### PR DESCRIPTION
This pull request adds settings to change the font family and size of text in terminals, because I think the default font size is slightly too small.

This is the new settings window:
![image](https://user-images.githubusercontent.com/30956441/71645937-d0c32300-2cdf-11ea-81a4-a98aeadb685f.png)
A few notes:
- The default settings are Monospace, 10. These are QTermWidget's default settings too.
- I chose to limit fonts in the select box to monospaced fonts.
- I was not sure what values would be good as a minimum and maximum font size, so I went with 1 and 100 (I'm not sure why anyone would use either one, so I guess this works fine).

This PR resolves issue #1.

If there's anything that needs to be changed, please let me know.